### PR TITLE
Bump sbt version of the tempalted code

### DIFF
--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.8


### PR DESCRIPTION
I bumped it to `1.2.8` (not `1.3.x`) to keep it consistent with the main build.

We can bump them both on a separate PR.