### PR TITLE
Multiple version bumps, extracted version values and gradle upgrade.

### DIFF
--- a/src/main/g8/build.gradle
+++ b/src/main/g8/build.gradle
@@ -38,6 +38,10 @@ configurations {
 
 dependencies {
 
+  compile 'com.typesafe.akka:akka-discovery_$scala_major_version$:$akka_version$'
+  compile 'com.typesafe.akka:akka-protobuf_$scala_major_version$:$akka_version$'
+  compile 'com.typesafe.akka:akka-stream_$scala_major_version$:$akka_version$'
+
   testImplementation 'com.typesafe.akka:akka-stream-testkit_2.12:$akka_version$'
   testImplementation 'org.scalatest:scalatest_2.12:3.0.8'
   testRuntime 'org.pegdown:pegdown:1.1.0'
@@ -67,4 +71,8 @@ task runClient(type: JavaExec) {
   // arguments to pass to the application
   if (project.hasProperty("GreeterClient.user"))
     args  project.getProperty("GreeterClient.user")
+}
+
+application {
+  mainClassName = 'com.example.helloworld.GreeterServer'
 }

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -11,7 +11,7 @@ enablePlugins(AkkaGrpcPlugin)
 
 // ALPN agent
 enablePlugins(JavaAgent)
-javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.10" % "runtime;test"
+javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "$jetty_alpn_agent_version$" % "runtime;test"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-discovery" % akkaVersion,

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,6 +1,9 @@
 name = akka-grpc-quickstart-scala
 description = Akka gRPC is a toolkit for building streaming gRPC servers and clients on top of Akka Streams. This simple application will get you started building gRPC based systems with Scala. This app uses Akka, Scala, and ScalaTest.
-akka_grpc_version=maven(com.lightbend.akka.grpc, akka-grpc-runtime_2.12)
+akka_grpc_version=maven(com.lightbend.akka.grpc, akka-grpc-runtime_2.13, stable)
 akka_version=maven(com.typesafe.akka, akka-actor_2.13, stable)
-scala_version=2.13.1
+sbt_version=maven(org.scala-sbt, sbt)
+jetty_alpn_agent_version=maven(org.mortbay.jetty.alpn, jetty-alpn-agent, stable)
+scala_major_version=2.13
+scala_version=2.13.2
 verbatim=*.scala *.conf *.proto *.pem *.key gradlew gradlew.bat gradle-wrapper.properties gradle-wrapper.jar

--- a/src/main/g8/pom.xml
+++ b/src/main/g8/pom.xml
@@ -13,27 +13,29 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <akka.version>$akka_version$</akka.version>
     <akka.grpc.version>$akka_grpc_version$</akka.grpc.version>
-    <grpc.version>1.13.1</grpc.version>
+    <scala.binary.version>$scala_major_version$</scala.binary.version>
+    <jetty.alpn.agent.version>$jetty_alpn_agent_version$</jetty.alpn.agent.version>
+    <grpc.version>1.28.1</grpc.version>
     <project.encoding>UTF-8</project.encoding>
   </properties>
   
   <dependencies>
     <dependency>
       <groupId>com.lightbend.akka.grpc</groupId>
-      <artifactId>akka-grpc-runtime_2.12</artifactId>
+      <artifactId>akka-grpc-runtime_\${scala.binary.version}</artifactId>
       <version>\${akka.grpc.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-stream-testkit_2.12</artifactId>
+      <artifactId>akka-stream-testkit_\${scala.binary.version}</artifactId>
       <version>\${akka.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.12</artifactId>
+      <artifactId>scalatest_\${scala.binary.version}</artifactId>
       <version>3.0.5</version>
       <scope>test</scope>
     </dependency>
@@ -48,7 +50,7 @@
     <dependency>
       <groupId>org.mortbay.jetty.alpn</groupId>
       <artifactId>jetty-alpn-agent</artifactId>
-      <version>2.0.7</version>
+      <version>\${jetty.alpn.agent.version}</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=$sbt_version$


### PR DESCRIPTION
References #35

Related to https://github.com/akka/akka-grpc-quickstart-java.g8/pull/32

Some changes are to bring this `.g8` template closer to the java counterpart.


NOTE: I'm purposedly not bumping any dependency on the project itself and focusing this PR on the generated code only.
