### PR TITLE
Revert scala.binary.version bump for gradle usage

### DIFF
--- a/src/main/g8/build.gradle
+++ b/src/main/g8/build.gradle
@@ -38,9 +38,9 @@ configurations {
 
 dependencies {
 
-  compile 'com.typesafe.akka:akka-discovery_$scala_major_version$:$akka_version$'
-  compile 'com.typesafe.akka:akka-protobuf_$scala_major_version$:$akka_version$'
-  compile 'com.typesafe.akka:akka-stream_$scala_major_version$:$akka_version$'
+  compile 'com.typesafe.akka:akka-discovery_2.12:$akka_version$'
+  compile 'com.typesafe.akka:akka-protobuf_2.12:$akka_version$'
+  compile 'com.typesafe.akka:akka-stream_2.12:$akka_version$'
 
   testImplementation 'com.typesafe.akka:akka-stream-testkit_2.12:$akka_version$'
   testImplementation 'org.scalatest:scalatest_2.12:3.0.8'


### PR DESCRIPTION
References https://github.com/akka/akka-grpc-quickstart-java.g8/issues/36

(port of https://github.com/akka/akka-grpc-quickstart-java.g8/pull/37 to this template)