### PR TITLE
Apparently the order matters

### DIFF
--- a/src/main/g8/build.gradle
+++ b/src/main/g8/build.gradle
@@ -6,8 +6,8 @@ plugins {
 }
 
 repositories {
-  mavenLocal()
   mavenCentral()
+  mavenLocal()
 }
 
 dependencies {


### PR DESCRIPTION
IDK how the build in https://github.com/akka/akka-grpc-quickstart-scala.g8/pull/43 succeeded but without this reorder I can't use a newly create gradle project.
