### PR TITLE
bump(GH workflow): ubuntu 24.04; schedule once a month

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 0 */7 * *"
+    - cron: "0 0 1 * *"
 
 permissions:
   contents: read
@@ -15,7 +15,7 @@ jobs:
   check:
     name: Build and test
     if: github.repository == 'akka/akka-grpc-quickstart-scala.g8'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Ubuntu 20.04 is about to be decommissioned.
Running once a month should be enough.